### PR TITLE
Zha configure reporting - switch

### DIFF
--- a/homeassistant/components/switch/zha.py
+++ b/homeassistant/components/switch/zha.py
@@ -35,8 +35,8 @@ async def make_sensor(discovery_info):
         in_clusters = discovery_info['in_clusters']
         cluster = in_clusters[OnOff.cluster_id]
         await zha.configure_reporting(
-            sensor.entity_id, cluster, sensor.value_attribute, min_report=0, max_report=600,
-            reportable_change=1
+            sensor.entity_id, cluster, sensor.value_attribute,
+            min_report=0, max_report=600, reportable_change=1
         )
 
     return sensor

--- a/homeassistant/components/switch/zha.py
+++ b/homeassistant/components/switch/zha.py
@@ -21,13 +21,28 @@ async def async_setup_platform(hass, config, async_add_entities,
     if discovery_info is None:
         return
 
-    from zigpy.zcl.clusters.general import OnOff
-    in_clusters = discovery_info['in_clusters']
-    cluster = in_clusters[OnOff.cluster_id]
-    await cluster.bind()
-    await cluster.configure_reporting(0, 0, 600, 1,)
+    sensor = await make_sensor(discovery_info)
+    async_add_entities([sensor], update_before_add=True)
 
-    async_add_entities([Switch(**discovery_info)], update_before_add=True)
+
+async def make_sensor(discovery_info):
+    """Create ZHA sensors factory."""
+    from zigpy.zcl.clusters.general import OnOff
+
+    sensor = Switch(**discovery_info)
+
+    if discovery_info['new_join']:
+        in_clusters = discovery_info['in_clusters']
+        cluster = in_clusters[OnOff.cluster_id]
+        await zha.configure_reporting(
+            sensor.entity_id, cluster, sensor.value_attribute, min_report=0, max_report=600,
+            reportable_change=1
+        )
+
+#        await cluster.bind()
+#        await cluster.configure_reporting(sensor.value_attribute, 0, 600, 1)
+
+    return sensor
 
 
 class Switch(zha.Entity, SwitchDevice):


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
